### PR TITLE
Export jluna as CMake targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-/libjluna.so
-/libjluna_c_adapter.so
+/libjluna*.so
+/libjluna_c_adapter*.so
 /.src/include_julia.inl
 /.benchmark/results/
 /docs/bckp.txt
+/build
+/.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,11 @@
 cmake_minimum_required(VERSION 3.16)
 project(jluna)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_BUILD_TYPE Debug)
-
 # compiler support
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION STRGREATER_EQUAL "12.0.0")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2b -lstdc++")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-volatile")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION STRGREATER_EQUAL "10.0.0")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fconcepts")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fconcepts -Wno-volatile")
 else()
     message(FATAL_ERROR "Currently, the only supported compilers are G++10, G++11 (recommended) and Clang-12")
 endif()
@@ -51,11 +48,9 @@ else()
     message(FATAL_ERROR "Failed to detect julia image. Make sure JULIA_PATH is set correctly and that the julia image is uncompressed and not corrupted.\nFor more information, visit https://github.com/Clemapfel/jluna/blob/master/README.md#troubleshooting")
 endif()
 
-include_directories(${JULIA_INCLUDE})
 
 ### JLUNA ###
 
-include_directories(${CMAKE_SOURCE_DIR})
 
 set(RESOURCE_PATH ${CMAKE_SOURCE_DIR})
 configure_file(${CMAKE_SOURCE_DIR}/.src/include_julia.inl.in ${CMAKE_SOURCE_DIR}/.src/include_julia.inl @ONLY)
@@ -124,6 +119,7 @@ add_library(jluna SHARED
 set_target_properties(jluna PROPERTIES
     LINKER_LANGUAGE C
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}
+    DEBUG_POSTFIX -debug
 )
 
 add_library(jluna_c_adapter SHARED
@@ -131,13 +127,22 @@ add_library(jluna_c_adapter SHARED
     .src/c_adapter.cpp
 )
 
+target_include_directories(jluna_c_adapter
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    # The user should include julia it own his own
+    PUBLIC $<BUILD_INTERFACE:${JULIA_INCLUDE}>
+)
+
+target_compile_features(jluna_c_adapter PUBLIC cxx_std_20)
+target_link_libraries(jluna_c_adapter PUBLIC $<BUILD_INTERFACE:${JULIA_LIB}>)
+
 set_target_properties(jluna_c_adapter PROPERTIES
     LINKER_LANGUAGE C
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}
+    DEBUG_POSTFIX -debug
 )
 
-target_link_libraries(jluna_c_adapter ${JULIA_LIB})
-target_link_libraries(jluna jluna_c_adapter ${JULIA_LIB})
+target_link_libraries(jluna PUBLIC jluna_c_adapter)
 
 ### EXECUTABLES ###
 
@@ -152,3 +157,32 @@ target_link_libraries(JLUNA_TEST jluna ${JULIA_LIB})
 #   .benchmark/benchmark.hpp
 #)
 #target_link_libraries(JLUNA_BENCHMARK jluna ${JULIA_LIB})
+
+
+include(GNUInstallDirs)
+
+# TODO: ConfigVersion.cmake
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/jluna-config.cmake [[
+if (NOT ((CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION STRGREATER_EQUAL "12.0.0") OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION STRGREATER_EQUAL "10.0.0")))
+    message(FATAL_ERROR "Currently, the only supported compilers are G++10, G++11 (recommended) and Clang-12")
+endif()
+include("${CMAKE_CURRENT_LIST_DIR}/jluna-targets.cmake")
+]])
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/jluna-config.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/jluna
+)
+
+install(TARGETS jluna jluna_c_adapter EXPORT jluna_targets)
+
+install(EXPORT jluna_targets
+    FILE jluna-targets.cmake
+    NAMESPACE jluna::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/jluna
+)
+
+install(FILES jluna.hpp ${headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/jluna)
+install(DIRECTORY include .src DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/jluna)
+
+target_include_directories(jluna INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/jluna>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ add_library(jluna_c_adapter SHARED
 
 target_include_directories(jluna_c_adapter
     PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-    # The user should include julia it own his own
+    # users should include julia on their own
     PUBLIC $<BUILD_INTERFACE:${JULIA_INCLUDE}>
 )
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -157,39 +157,24 @@ cmake_minimum_required(VERSION 3.16)
 # name of our project
 project(MyProject)
 
-# cmake and cpp settings
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_BUILD_TYPE Debug)
-
-# compiler
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lstdc++")
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fconcepts")
-else()
-    message(FATAL_ERROR "only g++11 or clang-12 are supported")
-endif()
-
 # julia
 if (NOT DEFINED ENV{JULIA_PATH})
     message(WARNING "JULIA_PATH was not set correctly. Consider re-reading the jluna installation tutorial at https://github.com/Clemapfel/jluna/blob/master/docs/installation.md#setting-julia_path to fix this issue")
 endif()
 
+set(JULIA_INCLUDE "$ENV{JULIA_PATH}/include/julia")
+
 set(JULIA_LIB "$ENV{JULIA_PATH}/lib/libjulia.so")
 
-# find jluna and jluna_c_adapter
-find_library(JLUNA_LIB REQUIRED NAMES libjluna.so PATHS "${CMAKE_SOURCE_DIR}/jluna/")
-find_library(JLUNA_C_ADAPTER_LIB REQUIRED NAMES libjluna_c_adapter.so PATHS "${CMAKE_SOURCE_DIR}/jluna/")
-
-# include directories we'll need
-include_directories("${CMAKE_SOURCE_DIR}/jluna")
-include_directories("$ENV{JULIA_PATH}/include/julia")
+find_package(jluna REQUIRED)
 
 # add our executable
 add_executable(MY_EXECUTABLE ${CMAKE_SOURCE_DIR}/main.cpp)
 
+target_include_directories(MY_EXECUTABLE PRIVATE ${JULIA_INCLUDE})
+
 # link executable with jluna, jluna_c_adapter and julia
-target_link_libraries(MY_EXECUTABLE ${JLUNA_LIB} ${JLUNA_C_ADAPTER_LIB} ${JULIA_LIB})
+target_link_libraries(MY_EXECUTABLE jluna::jluna ${JULIA_LIB})
 ```
 
 We again save and close the file, then create our own build folder and run cmake, just like we did with `jluna` before

--- a/include/box.hpp
+++ b/include/box.hpp
@@ -11,7 +11,7 @@
 #include <unordered_map>
 #include <set>
 
-#include <julia/julia.h>
+#include <julia.h>
 
 #include <include/concepts.hpp>
 #include <include/typedefs.hpp>

--- a/include/unbox.hpp
+++ b/include/unbox.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <julia/julia.h>
+#include <julia.h>
 
 #include <include/concepts.hpp>
 #include <include/typedefs.hpp>


### PR DESCRIPTION
Exporting these targets may greatly simply the process of using this library, as shown in docs/installation.md.
Also, since this library targets "modern"ness, modern CMake does not encourage the use of global functions like `include_directories` or global variables like `CMAKE_CXX_STANDARD`, so I replaced them with ones that can propagate between targets.
As for `lstdc++`, it should not be needed if you set `CMAKE_CXX_COMPILER` to clang++ instead of clang.
Also fix #6.