### PR TITLE
Implement Task's operator unsafe::Value*() + minor fixes

### DIFF
--- a/.src/multi_threading.inl
+++ b/.src/multi_threading.inl
@@ -245,7 +245,7 @@ namespace jluna
 
     inline Task<void>::~Task()
     {
-        if (_value == nullptr)
+        if (_value != nullptr)
             ThreadPool::free(_value->_threadpool_id);
     }
 

--- a/.src/multi_threading.inl
+++ b/.src/multi_threading.inl
@@ -256,11 +256,10 @@ namespace jluna
 
     inline Task<void>::operator unsafe::Value*()
     {
-        auto* res = _value->_value;
-        if (res == nullptr)
+        if (_value == nullptr)
             return jl_nothing;
         else
-            return res;
+            return _value->_value;
     }
 
     inline Task<void>& Task<void>::operator=(Task&& other)

--- a/.src/multi_threading.inl
+++ b/.src/multi_threading.inl
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 Clemens Cords
 // Created on 12.04.22 by clem (mail@clemens-cords.com)
 //
@@ -111,7 +111,7 @@ namespace jluna
 
         _value_id = unsafe::gc_preserve(_value);
     }
-    
+
     template<typename T>
     Task<T>::Task(detail::TaskValue<T>* ptr)
         : _value(ptr)
@@ -129,6 +129,16 @@ namespace jluna
     {
         _value = std::move(other._value);
         other._value = nullptr;
+    }
+
+    template<typename T>
+    Task<T>::operator unsafe::Value*()
+    {
+        auto* res = _value->_value;
+        if (res == nullptr)
+            return jl_nothing;
+        else
+            return res;
     }
 
     template<typename T>
@@ -243,6 +253,15 @@ namespace jluna
     {
         _value = std::move(other._value);
         other._value = nullptr;
+    }
+
+    inline Task<void>::operator unsafe::Value*()
+    {
+        auto* res = _value->_value;
+        if (res == nullptr)
+            return jl_nothing;
+        else
+            return res;
     }
 
     inline Task<void>& Task<void>::operator=(Task&& other)

--- a/.src/multi_threading.inl
+++ b/.src/multi_threading.inl
@@ -291,7 +291,7 @@ namespace jluna
     inline bool Task<void>::is_done() const
     {
         if (_value == nullptr)
-            false;
+            return false;
 
         static auto* istaskdone = unsafe::get_function(jl_base_module, "istaskdone"_sym);
         return jl_unbox_bool(jluna::safe_call(istaskdone, _value->_value));
@@ -300,7 +300,7 @@ namespace jluna
     inline bool Task<void>::is_failed() const
     {
         if (_value == nullptr)
-            true;
+            return true;
 
         static auto* istaskfailed = unsafe::get_function(jl_base_module, "istaskfailed"_sym);
         return jl_unbox_bool(jluna::safe_call(istaskfailed, _value->_value));

--- a/.src/multi_threading.inl
+++ b/.src/multi_threading.inl
@@ -134,11 +134,10 @@ namespace jluna
     template<typename T>
     Task<T>::operator unsafe::Value*()
     {
-        auto* res = _value->_value;
-        if (res == nullptr)
+        if (_value == nullptr)
             return jl_nothing;
         else
-            return res;
+            return _value->_value;
     }
 
     template<typename T>

--- a/.test/main.cpp
+++ b/.test/main.cpp
@@ -1439,6 +1439,21 @@ int main()
         task_b.back().join();
     });
 
+    Test::test("Task: access task proxy", []()
+    {
+        auto lambda_void = []() {};
+        auto lambda_size_t = []() -> size_t {return 4;};
+
+        auto task_a = ThreadPool::create<void()>(lambda_void);
+        auto task_b = ThreadPool::create<size_t()>(lambda_size_t);
+
+        auto task_a_proxy = Proxy(static_cast<unsafe::Value*>(task_a));
+        auto task_b_proxy = Proxy(static_cast<unsafe::Value*>(task_b));
+
+        Test::assert_that((bool)task_a_proxy["sticky"] == false);
+        Test::assert_that((bool)task_b_proxy["sticky"] == false);
+    });
+
     return Test::conclude() ? 0 : 1;
 }
 

--- a/.test/main.cpp
+++ b/.test/main.cpp
@@ -1422,6 +1422,16 @@ int main()
         Test::assert_that(task.result().get().value() == 4);
     });
 
+    Test::test("Task<void>: schedule/join", []()
+    {
+        auto task = ThreadPool::create<void()>([]() {});
+
+        Test::assert_that(not task.is_running());
+        task.schedule();
+        task.join();
+        Test::assert_that(task.is_done());
+    });
+
     Test::test("Task: move ctor", []()
     {
         std::vector<Task<size_t>> task_a;
@@ -1430,6 +1440,21 @@ int main()
         }));
 
         std::vector<Task<size_t>> task_b;
+        task_b.emplace_back(std::move(task_a.back()));
+
+        task_a.back().schedule();
+        task_b.back().schedule();
+
+        task_a.back().join();
+        task_b.back().join();
+    });
+
+    Test::test("Task<void>: move ctor", []()
+    {
+        std::vector<Task<void>> task_a;
+        task_a.push_back(ThreadPool::create<void()>([]() {}));
+
+        std::vector<Task<void>> task_b;
         task_b.emplace_back(std::move(task_a.back()));
 
         task_a.back().schedule();

--- a/docs/multi_threading.md
+++ b/docs/multi_threading.md
@@ -441,7 +441,7 @@ We can access the Julia-side object, `jluna::Task` is managing, using `operator 
 auto lambda = [](){ //...
     
 // create task
-auto task = ThreadPool::create<void>(lambda);
+auto task = ThreadPool::create<void()>(lambda);
 
 // create proxy to task
 auto task_proxy = Proxy(static_cast<unsafe::Value*>(task));


### PR DESCRIPTION
Draft PR which fixes #30.
Also small fixes to `Task<void>`'s destructor, `is_done()`, `is_failed()`.
Finally, added specific tests for the Task<void> case. I'm not attached to these at all, just a suggestion. Not sure if you want to organize them differently.

Noticed Proxy has const versions of the `operator unsafe::Value*()`, I'm not sure if Task should have that?