### PR TITLE
Add usertype-related macro, fix usertype::implement scoping

### DIFF
--- a/.src/usertype.inl
+++ b/.src/usertype.inl
@@ -75,7 +75,7 @@ namespace jluna
         for (auto& field_name : _fieldnames_in_order)
             jluna::safe_call(setfield, template_proxy, (unsafe::Value*) std::get<0>(_mapping.at(field_name))(default_instance), (unsafe::Value*) field_name);
 
-        _type = std::make_unique<Type>((jl_datatype_t*) jluna::safe_call(implement, template_proxy));
+        _type = std::make_unique<Type>((jl_datatype_t*) jluna::safe_call(implement, template_proxy, module));
         _implemented = true;
         gc_unpause;
     }

--- a/.test/main.cpp
+++ b/.test/main.cpp
@@ -19,6 +19,7 @@ struct NonJuliaType
     std::vector<size_t> _field;
 };
 set_usertype_enabled(NonJuliaType);
+make_usertype_implicitly_convertible(NonJuliaType);
 
 #include <thread>
 

--- a/include/usertype.hpp
+++ b/include/usertype.hpp
@@ -84,6 +84,9 @@ namespace jluna
                 Type
             >> _mapping = {};
     };
-}
 
+    /// @brief declare T to be implicitly convertible to it's same-named Julia-side equivalent. The user is responsible for assuring the usertype interface for T is fully specified and implemented, otherwise behavior of calling box on the type is undefined.
+    /// @param T: usertype-wrapped type, for example if `MyType` should be implicitly convertible, `Usertype<MyType>` needs to be specified, `set_usertype_enable(MyType)` needs to have been called, then `make_usertype_implicitly_convertible(MyType)` will enable the conversion
+    #define make_usertype_implicitly_convertible(T) namespace jluna::detail { template<> struct as_julia_type_aux<T> { static inline const std::string type_name = #T; }; }
+}
 #include <.src/usertype.inl>

--- a/include/usertype.hpp
+++ b/include/usertype.hpp
@@ -85,8 +85,8 @@ namespace jluna
             >> _mapping = {};
     };
 
-    /// @brief declare T to be implicitly convertible to it's same-named Julia-side equivalent. The user is responsible for assuring the usertype interface for T is fully specified and implemented, otherwise behavior of calling box on the type is undefined.
-    /// @param T: usertype-wrapped type, for example if `MyType` should be implicitly convertible, `Usertype<MyType>` needs to be specified, `set_usertype_enable(MyType)` needs to have been called, then `make_usertype_implicitly_convertible(MyType)` will enable the conversion
+    /// @brief declare T to be implicitly convertible to its same-named Julia-side equivalent. The user is responsible for assuring the usertype interface for T is fully specified and implemented, otherwise behavior of calling box on the type is undefined.
+    /// @param T: usertype-wrapped type, for example if `MyType` should be implicitly convertible, `Usertype<MyType>` needs to be specified, `set_usertype_enable(MyType)` needs to have been called, then `make_usertype_implicitly_convertible(MyType)` will enable the conversion once `Usertype<MyType>::implement` was called during runtime
     #define make_usertype_implicitly_convertible(T) namespace jluna::detail { template<> struct as_julia_type_aux<T> { static inline const std::string type_name = #T; }; }
 }
 #include <.src/usertype.inl>


### PR DESCRIPTION
Add additional macro for implicit type conversion from a usertype-wrapped type, c.f. #35.

Fix a typo that called usertype::implement in Main-scope, rather than the specified scope, c.f. #36.

Thank you to @paulerikf for pointing these out.