### PR TITLE
Add image_path to initialize, to allow init with custom image

### DIFF
--- a/.src/safe_utilities.cpp
+++ b/.src/safe_utilities.cpp
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 Clemens Cords
 // Created on 04.04.22 by clem (mail@clemens-cords.com)
 //
@@ -21,7 +21,8 @@ namespace jluna
         size_t n_threads,
         bool suppress_log,
         const std::string& jluna_shared_library_path,
-        const std::string& julia_image_path
+        const std::string& julia_bindir,
+        const std::string& image_path
     )
     {
         static bool is_initialized = false;
@@ -45,10 +46,14 @@ namespace jluna
         #endif
 
         detail::_num_threads = n_threads;
-        if (julia_image_path.empty())
+        if (julia_bindir.empty() && image_path.empty())
             jl_init();
+        else if (image_path.empty())
+            jl_init_with_image(julia_bindir.c_str(), nullptr);
+        else if (julia_bindir.empty())
+            jl_init_with_image(nullptr, image_path.c_str());
         else
-            jl_init_with_image(julia_image_path.c_str(), nullptr);
+            jl_init_with_image(julia_bindir.c_str(), image_path.c_str());
 
         forward_last_exception();
 

--- a/.src/safe_utilities.cpp
+++ b/.src/safe_utilities.cpp
@@ -46,7 +46,7 @@ namespace jluna
         #endif
 
         detail::_num_threads = n_threads;
-        if (julia_bindir.empty() && image_path.empty())
+        if (julia_bindir.empty() and image_path.empty())
             jl_init();
         else if (image_path.empty())
             jl_init_with_image(julia_bindir.c_str(), nullptr);

--- a/include/safe_utilities.hpp
+++ b/include/safe_utilities.hpp
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 Clemens Cords
 // Created on 04.04.22 by clem (mail@clemens-cords.com)
 //
@@ -18,12 +18,14 @@ namespace jluna
     /// @param n_threads: number of threads to initialize the julia threadpool with. Default: 1
     /// @param suppress_log: should logging be disabled. Default: No
     /// @param jluna_shared_library_path: absolute path that is the location of libjluna.so. Leave empty to use default path
-    /// @param jluna_image_path: absolute path that is the location of the julia image. Leave empty to use default path
+    /// @param julia_bindir: absolute path that is the location of the julia image. Leave empty to use default path
+    /// @param image_path: the path of a system image file (*.so), a non-absolute path is interpreted as relative to julia_bindir
     void initialize(
         size_t n_threads = 1,
         bool suppress_log = false,
         const std::string& jluna_shared_library_path = "",
-        const std::string& julia_image_path = ""
+        const std::string& julia_bindir = "",
+        const std::string& image_path = ""
     );
 
     /// @brief call function with args, with verbose exception forwarding


### PR DESCRIPTION
I needed the ability to initialize with a custom sys image, so modified the `jluna::initialize` function a bit. Don't know if this is something you'd want in jluna, or even if it could cause other issues really... But dropping a draft PR here just in case.

`julia_image_path` changed to `julia_bindir` so that it and the new `image_path` args match up with the julia C API args for `jl_init_with_imag`.

