### PR TITLE
Silence warning "copy relocation against non-copyable protected symbol"

### DIFF
--- a/.src/multi_threading.inl
+++ b/.src/multi_threading.inl
@@ -266,6 +266,7 @@ namespace jluna
     {
         _value = std::move(other._value);
         other._value = nullptr;
+        return *this;
     }
 
     inline void Task<void>::join()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ Options
 
 #]=======================================================================]
 
-project(jluna VERSION 0.9.1 LANGUAGES CXX)
+project(jluna VERSION 1.0.0 LANGUAGES CXX)
 
 include(cmake/project-is-top-level.cmake)
 if(PROJECT_IS_TOP_LEVEL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ Options
 
 #]=======================================================================]
 
-project(jluna VERSION 1.0.0 LANGUAGES CXX)
+project(jluna VERSION 0.9.1 LANGUAGES CXX)
 
 include(cmake/project-is-top-level.cmake)
 if(PROJECT_IS_TOP_LEVEL)
@@ -140,9 +140,9 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
     include(cmake/install-rules.cmake)
 endif()
 
+include(CTest)
 ### Declare Test ###
 
-include(CTest)
 option(BUILD_TESTING "Enable jluna_test" ON)
 if (BUILD_TESTING)
     add_executable(
@@ -154,7 +154,7 @@ if (BUILD_TESTING)
     add_test(NAME jluna_test COMMAND jluna_test)
 endif()
 
-### Developer Mode ###
+### Developer mode ###
 
 if(NOT jluna_DEVELOPER_MODE)
     return()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ Options
 
 #]=======================================================================]
 
-project(jluna VERSION 0.9.1 LANGUAGES CXX)
+project(jluna VERSION 1.0.0 LANGUAGES CXX)
 
 include(cmake/project-is-top-level.cmake)
 if(PROJECT_IS_TOP_LEVEL)
@@ -140,9 +140,9 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
     include(cmake/install-rules.cmake)
 endif()
 
-include(CTest)
 ### Declare Test ###
 
+include(CTest)
 option(BUILD_TESTING "Enable jluna_test" ON)
 if (BUILD_TESTING)
     add_executable(
@@ -154,7 +154,7 @@ if (BUILD_TESTING)
     add_test(NAME jluna_test COMMAND jluna_test)
 endif()
 
-### Developer mode ###
+### Developer Mode ###
 
 if(NOT jluna_DEVELOPER_MODE)
     return()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,4 +177,5 @@ if (BUILD_BENCHMARK) # AND NOT WIN32)
         .benchmark/benchmark_aux.hpp
     )
     target_link_libraries(jluna_benchmark PRIVATE jluna)
+    target_compile_options(jluna_benchmark PRIVATE "-fpic")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,7 @@ if (BUILD_TESTING)
         .test/test.hpp
     )
     target_link_libraries(jluna_test PRIVATE jluna)
+    target_compile_options(jluna_test PRIVATE "-fpic")
     add_test(NAME jluna_test COMMAND jluna_test)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ Options
 
 #]=======================================================================]
 
-project(jluna VERSION 1.0.0 LANGUAGES CXX)
+project(jluna VERSION 0.9.1 LANGUAGES CXX)
 
 include(cmake/project-is-top-level.cmake)
 if(PROJECT_IS_TOP_LEVEL)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jluna: A modern Julia <-> C++ Wrapper (v0.9.2)
+# jluna: A modern Julia <-> C++ Wrapper (v1.0.0)
 
 
 ![](./header.png)
@@ -21,7 +21,7 @@ jluna aims to fully wrap the official Julia C-API, replacing it in projects with
    5.3 [cmake 3.12+](#dependencies)<br>
 6. [License](#license)
 7. [Authors](#credits)
-   
+
 ---
 
 ### Showcase
@@ -66,7 +66,7 @@ Base["println"](matrix);
 
 // iterable
 for (auto element : matrix)
-    element = static_cast<Int64>(element) + 1;
+element = static_cast<Int64>(element) + 1;
 Base["println"](matrix);
 
 // supports list indexing
@@ -85,11 +85,11 @@ Base["println"](generated_vector);
 // C++ function: concatenate all elements of input array
 auto cpp_function = [](jluna::ArrayAny1d array_in) -> std::string
 {
-    std::stringstream str;
-    for (auto e : array_in)
-        str << static_cast<std::string>(e) << " ";
+std::stringstream str;
+for (auto e : array_in)
+str << static_cast<std::string>(e) << " ";
 
-    return str.str();
+return str.str();
 };
 
 // bind to Julia variable
@@ -114,32 +114,32 @@ initialize(8);
 // custom synchronization primitive 
 // that works in both Julia and C++
 auto mutex = jluna::Mutex();
- 
+
 // thread behavior: write current thread id to vector
 std::vector<size_t> to_write_to;
 auto task_function = [&]() -> void
 {
-    mutex.lock();
-    to_write_to.push_back(ThreadPool::thread_id());
-    mutex.unlock();
+mutex.lock();
+to_write_to.push_back(ThreadPool::thread_id());
+mutex.unlock();
 };
 
 // create tasks and store them until they are finished
 std::vector<Task<void>> tasks;
 for (size_t i = 0; i < 2 * ThreadPool::n_threads(); ++i)
 {
-    // spawn task
-    tasks.push_back(ThreadPool::create<void()>(task_function));
-    tasks.back().schedule();
+// spawn task
+tasks.push_back(ThreadPool::create<void()>(task_function));
+tasks.back().schedule();
 }
 
 // wait for all tasks to finish
 for (auto& task : tasks)
-    task.join();
+task.join();
 
 // print
 for (auto id : to_write_to)
-    std::cout << id << " ";
+std::cout << id << " ";
 std::cout << std::endl;
 
 // result shows which threads of the threadpool executed which task
@@ -157,37 +157,37 @@ std::cout << std::endl;
 + thread-safe, provides a custom thread pool that, [unlike the C-API](https://clemens-cords.com/jluna/multi_threading.html), allows for concurrent interfacing with Julia
 + `std::` types & usertypes can be moved freely between Julia and C++
 + call arbitrary C++ functions from Julia
-+ multi-dimensional, iterable array interface
++ multidimensional, iterable array interface
 + provides < 5% overhead functions, viable in performance-critical environments
 + full exception forwarding, verbose error messages
 + complete [manual](https://clemens-cords.com/jluna/basics.html), [installation guide](https://clemens-cords.com/jluna/installation.md), [benchmark analysis](https://clemens-cords.com/jluna/benchmarks.html), inline documentation for IDEs - all written by a human
 + and more!
 
-### Planned (but not yet implemented):
+## Long-Term Support
 
-jluna is feature complete as of 0.9.0. The library will continue to be supported. If no major issues or feature request come up, 0.9 will be upgraded to 1.0 in Winter 2022.
+jluna entered version 1.0.0 in February 2023. While feature complete, the following areas would benefit from additional development:
++ **Windows Support**: Currently, the library should compile on a Windows machine with a sufficiently new compiler, stability remains untested, mostly due to the fact the developer does not currently have access to a Windows workstation
++ **Foreign Thread Support**: With Julia 1.9.0 foreign thread support [seems to have been implemented](https://github.com/JuliaLang/Julia/pull/45447), however, until 1.9.0 becomes the stable release, jluna will not utilize this new feature
 
 ---
 
 ## Documentation
 
-Documentation, including a step-by-step installation and troubleshooting guide, tutorial, and index of all functions and objects in jluna is available 
+Documentation, including a step-by-step installation and troubleshooting guide, tutorial, and index of all functions and objects in jluna is available
 [here](https://clemens-cords.com/jluna).
 
 ---
 
 ## Dependencies
 
-jluna aims to be as modern as is practical. It uses C++20 features extensively and aims to support the newest julia version, rather than focusing on backwards compatibility. 
+jluna aims to be as modern as is practical. It uses C++20 features extensively and aims to support the newest stable Julia version, rather than focusing on backwards compatibility.
 
 For jluna you'll need:
 + [**Julia 1.7.0**](https://julialang.org/downloads/#current_stable_release) (or higher)
 + [**cmake 3.12**](https://cmake.org/download/) (or higher)
 + C++ Compiler (see below)
 
-Currently [**g++10**](https://askubuntu.com/questions/1192955/how-to-install-g-10-on-ubuntu-18-04), [**g++11**](https://lindevs.com/install-g-on-ubuntu/) and [**clang++-12**](https://linux-packages.com/ubuntu-focal-fossa/package/clang-12) are fully supported. `g++-11` is the primary compiler used for development of jluna and is thus recommended. `MSVC 19.32` seems to work, but stability remains untested.
-
-> I currently do not have access to a windows environment for testing. If someone would like to open a PR or create a GitHub issue addressing windows-related problems, I'd be happy to review them and credit you! ~ C.
+Currently, [g++10](https://gcc.gnu.org/) (or newer) and [clang-12](https://releases.llvm.org/) (or newer) fully supported. `g++-11` is the primary compiler used for development of jluna and is thus recommended. `MSVC 19.32` (or newer) seems to work, but stability remains untested.
 
 ---
 
@@ -206,9 +206,9 @@ cd build
 ```
 cmake .. -DJULIA_BINDIR=$(julia -e "println(Sys.BINDIR)") -DCMAKE_CXX_COMPILER=<C++ Compiler> -DCMAKE_INSTALL_PREFIX=<install directory>
 ```
-Where 
+Where
 + `<C++ Compiler>` is one of `g++-10`, `g++-11`, `clang++-12`
-+ `<install directory>` is the desired install directory, usually `/usr/local` on unix, `C:/Program Files/jluna` on windows
++ `<install directory>` is the desired install directory, usually `/usr/local` on unix, `C:/Program Files/jluna` on Windows
 
 Then:
 ```
@@ -216,7 +216,7 @@ make install
 ctest --verbose
 ```
 
-Afterwards, you can make jluna available to your library using 
+Afterward, you can make jluna available to your library using
 
 ```cmake
 # inside your own CMakeLists.txt
@@ -228,7 +228,7 @@ target_link_libraries(<your library> PRIVATE
     "${jluna}" 
     "${<julia>}")
 ```
-Where 
+Where
 + `<install directory>` is the directory specified via `-DCMAKE_INSTALL_PREFIX`
 + `<julia>` is the Julia shared library (usually available in `"${JULIA_BINDIR}/../lib"`)
 + `<your library>` is the name of your library or executable
@@ -241,7 +241,7 @@ If any step of this does not work for you, please follow the [installation guide
 
 The current and all prior releases of jluna are supplied under MIT license, available [here](./LICENSE.txt).
 
-I would like to ask people using this library in commercial or university settings, to disclose their usage of jluna in some small way (for example, at the end of the credits or via a citation) and to make clear the origin of the work (for example by linking this github page). Unlike the text in `LICENSE.txt`, this is not a legally binding condition, only a personal request by me, the developer.
+I would like to ask people using this library in commercial or university settings, to disclose their usage of jluna in some small way (for example, at the end of the credits or via a citation) and to make clear the origin of the work (for example by linking this GitHub page). Unlike the text in `LICENSE.txt`, this is not a legally binding condition, only a personal request by me, the developer.
 
 Thank you for your consideration,
 C.

--- a/docs/multi_threading.md
+++ b/docs/multi_threading.md
@@ -53,6 +53,14 @@ Given this, we can immediately throw out using any of the C++ `std::thread`-rela
 
 All is not lost, however: jluna offers its own multi-threading framework, allowing for parallel execution of truly arbitrary C++ code - even if that code interacts with the Julia state.
 
+> **NOTE**: As of 02/2023, Julias current stable release (1.8.5) does not have foreign thread support, as of the merge of
+https://github.com/JuliaLang/Julia/pull/45447, however, julia 1.9.x will support foreign therads. This may vastly change
+how the jluna multi-threading interface works, for example the section above may no longer apply. Once the foreign threat
+support becomes part of the stable Julia release, jlunas multi-threading interface may be removed, deprecated or reworked completely.
+Because of this, any function mentioned in this section should be considered **experimental** and, unlike with most of jlunas other
+features, continuity between versions is not guaranteed.
+
+
 ### Initializing the Julia Threadpool
 
 In Julia, we have to decide the number of threads we want to use **before startup**.
@@ -79,7 +87,7 @@ If left unspecified, jluna will initialize Julia with exactly 1 thread. We can s
 using namespace jluna;
 
 initialize(JULIA_NUM_THREADS_AUTO);
-// equivalent to `julia -t auto`
+// equivalent to `Julia -t auto`
 ```
 
 This sets the number of threads to number of local CPUs, just like [setting environment variable `JULIA_NUM_THREADS` to `auto`](https://docs.julialang.org/en/v1/manual/multi-threading/#Starting-Julia-with-multiple-threads) would do for pure Julia.

--- a/include/multi_threading.hpp
+++ b/include/multi_threading.hpp
@@ -53,7 +53,8 @@ namespace jluna
         template<typename>struct TaskValue;
     }
 
-    /// @brief the result of a thread
+    /// @brief The result of a thread
+    /// @note jlunas multi-threading interface should be considered experimental and may be deprecated and/or marked for removal once Julia 1.9 releases
     template<typename Value_t>
     class Future
     {
@@ -86,6 +87,8 @@ namespace jluna
             std::unique_ptr<Value_t> _value;
     };
 
+    /// @brief wrapper around a Julia `Task`, concurrently executed
+    /// @note jlunas multi-threading interface should be considered experimental and may be deprecated and/or marked for removal once Julia 1.9 releases
     template<typename Result_t>
     class Task
     {
@@ -145,6 +148,7 @@ namespace jluna
     /// @brief threadpool that allows scheduled C++-side tasks to safely access the Julia State from within a thread.
     /// Pool cannot be resized, it will use the native Julia threads to execute any C++-side tasks
     /// @note during task creation, the copy ctor will be invoked for all arguments `args` and the functions return value. To avoid this, wrap the type in an std::ref
+    /// @note jlunas multi-threading interface should be considered experimental and may be deprecated and/or marked for removal once Julia 1.9 releases
     class ThreadPool
     {
         template<typename>
@@ -198,6 +202,7 @@ namespace jluna
     };
 
     /// @brief pause the current task, has to be called from within a task allocated via ThreadPool::create
+    /// @note jlunas multi-threading interface should be considered experimental and may be deprecated and/or marked for removal once Julia 1.9 releases
     void yield();
 }
 


### PR DESCRIPTION
Fixes #40 for `jluna_test` and `jluna_benchmark` targets 