### PR TITLE
fixed a potential typo in function call 

### DIFF
--- a/include/julia/jluna_06.jl
+++ b/include/julia/jluna_06.jl
@@ -110,7 +110,7 @@ module cppcall
         elseif n == N == 2
             return from_pointer(invoke_function(f, to_pointer(xs[1]), to_pointer(xs[2])));
         elseif n == N == 3
-            return from_pt(invoke_function(f, to_pointer(xs[1]), to_pointer(xs[2]), to_pointer(xs[3])));
+            return from_pointer(invoke_function(f, to_pointer(xs[1]), to_pointer(xs[2]), to_pointer(xs[3])));
         elseif N != 0 && N != 1 && N != 2 & N != 3
             return from_pointer(invoke_function(f, to_pointer([xs...])));
         else


### PR DESCRIPTION
Noticed that for lambda's with 3 args things where failing for some reason, but 1 and 2 things were fine, after looking at the generated code I think this is the issue. Changing it to `from_pointer` fixed things for me.